### PR TITLE
Add special 'date_' placeholders

### DIFF
--- a/Global/snippets.ini
+++ b/Global/snippets.ini
@@ -100,6 +100,12 @@ Command="
 
       for (var name in placeholders) {
         var values = placeholders[name].split(',')
+        if (name.substring(0,5)=='date_'){
+          values = dateString(values[0])  // date format: see http://doc.qt.io/qt-5/qdatetime.html#toString
+          if (values == ''){
+            values = 'Invalid datetime format'
+          }
+        }
         dialogVars.push(name)
         dialogVars.push((values.length == 1) ? values[0] : values)
       }


### PR DESCRIPTION
If the placeholder name starts with 'date_', the default text is interpreted according to dateString(default text).

For example, a snippet defined as:
  ${date_y:yyyy}-${date_m:MM}-${date_d:dd}

Will render as (for example):
  2018-07-02

The snippet can have both date_ and normal placeholders.