### PR TITLE
A plugin that prevents saving data from the KeePassXc password manager

### DIFF
--- a/Automatic/README.md
+++ b/Automatic/README.md
@@ -62,3 +62,6 @@ Synchronizes clipboard with other application session running on different X11 s
 
 For copied URLS tries to get web page title and icon and stores it with item in "url" tab.
 
+### [KeePassXC protector](keepassxc-protector.ini)
+
+A plugin that prevents saving data from the [KeePassXC](https://github.com/keepassxreboot/keepassxc) password manager.

--- a/Automatic/keepassxc-protector.ini
+++ b/Automatic/keepassxc-protector.ini
@@ -1,0 +1,20 @@
+[Command]
+Automatic=true
+Command="
+    copyq:
+    
+    if ( ! isClipboard() ) {
+    \tfail();
+    }
+    
+    var title = currentWindowTitle();
+    
+    if ( title.search( /KeePassXC$/ ) == -1 ) {
+    \tfail();
+    }
+    
+    ignore();"
+Icon=\xf21b
+Input=text/plain
+Name=KeePassXC protector v1.0.0 (@ventormo)
+

--- a/Automatic/keepassxc-protector.ini
+++ b/Automatic/keepassxc-protector.ini
@@ -7,7 +7,7 @@ Command="
     \tfail();
     }
     
-    var title = currentWindowTitle();
+    var title = str( data( \"application/x-copyq-owner-window-title\" ) );
     
     if ( title.search( /KeePassXC$/ ) == -1 ) {
     \tfail();
@@ -16,5 +16,5 @@ Command="
     ignore();"
 Icon=\xf21b
 Input=text/plain
-Name=KeePassXC protector v1.0.0 (@ventormo)
+Name=KeePassXC protector v1.0.1 (@ventormo)
 


### PR DESCRIPTION
[KeePassXC](https://github.com/keepassxreboot/keepassxc) — one of the most popular open source password managers.

This plugin blocks saving data from KeePassXC to CopyQ for security reasons.