### PR TITLE
Improve on two commands.

### DIFF
--- a/Application/next-previous.ini
+++ b/Application/next-previous.ini
@@ -4,7 +4,6 @@
     selectItems(currentItem() + 1)"
 1\Icon=\xf0ab
 1\InMenu=true
-1\MatchCommand=copyq: currentItem() + 1 < size() || fail()
 1\Name=Next
 1\Shortcut=ctrl+n
 2\Command="
@@ -12,7 +11,6 @@
     selectItems(currentItem() - 1)"
 2\Icon=\xf0aa
 2\InMenu=true
-2\MatchCommand=copyq: currentItem() > 0 || fail()
 2\Name=Previous
 2\Shortcut=ctrl+p
 size=2

--- a/Global/diff-latest-items.ini
+++ b/Global/diff-latest-items.ini
@@ -11,8 +11,8 @@ Command="
         // the selected item either doesn't contain text
         // or the command is run as global shortcut.
         // select the last two clipboard in this case.
-        item1 = read(0)
-        item2 = read(1)
+        item1 = read(1)
+        item2 = read(0)
     } else {
         item1 = selectedItem1
         item2 = selectedItem2


### PR DESCRIPTION
### diff_lastest_items

    Use more natual way to run diff lastest items.

    Infact, when we do compare on recent two clipboard item,
    e.g.

    first time copy => copy1
    second time copy => copy2

    Then, when invoke compare command use global key, copy1 passed
    as second arg,  and copy2 passed as first arg.

    I consider reverse order is more natually.

### next-previous

    The filter expression is not really needed in this case.

    https://github.com/hluk/CopyQ/issues/1284#issuecomment-617090264