### PR TITLE
Add "Convert Markdown to ..." command

### DIFF
--- a/Global/README.md
+++ b/Global/README.md
@@ -96,3 +96,36 @@ You can also run the command on any two items selected in the main window.
 By default, this command launches [Beyond Compare 4](https://www.scootersoftware.com/download.php)
 for doing the comparison.
 You can find examples of launching other tools like [WinMerge](https://winmerge.org/downloads) directly in the command's source code.
+
+### [Convert Markdown to ...](convert-markdown.ini)
+
+Converts text written in [Markdown syntax](https://daringfireball.net/projects/markdown/syntax)
+to desired format, which can be for example:
+
+* HTML
+* [Jira markup](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)
+* JSON (AST) (JSON representation of the parsed text; useful rather for contributors than users)
+* [LaTeX](https://en.wikipedia.org/wiki/LaTeX)
+
+The command can be run on any text selection via a global shortcut or over items selected
+in the main window.
+
+#### Installation
+
+This script relies on the [mistletoe](https://github.com/miyuchina/mistletoe) project to do the
+actual Markdown parsing and conversion.
+This in turn requires that [Python](https://www.python.org/downloads/) 3.x is installed on the user computer.
+
+At the time of writing, the mistletoe project seems to abandoned by its maintainers, so for example
+if a really working conversion to Jira markup is needed (see [PR #100](https://github.com/miyuchina/mistletoe/pull/100)),
+the recommended mistletoe installation steps are the following:
+
+    cd /path/to/directory/of/your/choice
+    git clone https://github.com/pbodnar/mistletoe.git
+    cd mistletoe
+    git checkout fix-jira-renderer
+    pip3 install -e .
+
+For output format "HTML + code highlighting", an additional Python module needs to be installed:
+
+    pip3 install pygments

--- a/Global/convert-markdown.ini
+++ b/Global/convert-markdown.ini
@@ -1,0 +1,83 @@
+[Command]
+Name=Convert Markdown to ...
+Command="
+    copyq:
+    // # get input text to be converted
+    
+    var markdown = str(input());
+    if (!markdown) {
+        copy();
+        markdown = clipboard();
+    }
+    
+    // # get conversion options from user
+    
+    var renderers = {
+        'HTML': 'mistletoe.html_renderer.HTMLRenderer',
+        'HTML + code highlighting': 'contrib.pygments_renderer.PygmentsRenderer', // requires: `pip3 install pygments`
+        'HTML + GitHub Wiki': 'contrib.github_wiki.GithubWikiRenderer',
+        'HTML + MathJax': 'contrib.mathjax.MathJaxRenderer',
+        'Jira': 'contrib.jira_renderer.JIRARenderer',
+        'JSON (AST)': 'mistletoe.ast_renderer.ASTRenderer',
+        'LaTeX': 'mistletoe.latex_renderer.LaTeXRenderer',
+    }
+    
+    var settingsPrefix = 'mdConv.';
+    var optFormat = 'Target format';
+    var optAddToHistory = 'Add result to clipboard history';
+    
+    var format = settings(settingsPrefix + optFormat);
+    var addToHistory = settings(settingsPrefix + optAddToHistory) == 'true';
+    
+    var options = dialog(
+        '.title', 'Convert Markdown to ...',
+        '.defaultChoice', format,
+        optFormat, Object.keys(renderers),
+        optAddToHistory, addToHistory
+    );
+    
+    if (!options) {
+        abort();
+    }
+    
+    // # parse and store the options
+    
+    format = options[optFormat];
+    addToHistory = options[optAddToHistory];
+    
+    settings(settingsPrefix + optFormat, format);
+    settings(settingsPrefix + optAddToHistory, addToHistory);
+    
+    // # do the conversion
+    
+    function tempFile(content) {
+        var file = new TemporaryFile();
+        file.openWriteOnly();
+        file.write(content);
+        file.close();
+        return file;
+    }
+    
+    var mdFile = tempFile(markdown);
+    
+    var cmdRes = execute('python', '-m', 'mistletoe', mdFile.fileName(), '--renderer', renderers[format]);
+    
+    if (!cmdRes || cmdRes.exit_code != 0) {
+        popup('', 'Conversion failed: ' + (cmdRes ? str(cmdRes.stderr) : 'Python executable is probably not available?'), -1);
+        fail();
+    }
+    
+    // # store conversion result
+    
+    var output = str(cmdRes.stdout);
+    if (addToHistory) {
+        add(output);
+    }
+    copy(output);
+    
+    popup('', 'Markdown successfully converted to ' + format + '!');
+    "
+InMenu=true
+IsGlobalShortcut=true
+Icon=\xf103
+GlobalShortcut=meta+alt+c

--- a/Global/convert-markdown.ini
+++ b/Global/convert-markdown.ini
@@ -22,7 +22,7 @@ Command="
         'LaTeX': 'mistletoe.latex_renderer.LaTeXRenderer',
     }
     
-    var settingsPrefix = 'mdConv.';
+    var settingsPrefix = 'convert-markdown/';
     var optFormat = 'Target format';
     var optAddToHistory = 'Add result to clipboard history';
     


### PR DESCRIPTION
Hi, I was looking for a way of how to convert my "nicely formatted" Markdown-like notes to "not so nice" Jira markup comments. And this new command that I would like to share is the result. 

It uses the [mistletoe](https://github.com/miyuchina/mistletoe) project that according to my research was the only one that contained at least a basically working Markdown-to-Jira converter. I only had to fix it a little bit to be really working (see [PR #100](https://github.com/miyuchina/mistletoe/pull/100)). I see there is an alternative project called [mistune](https://github.com/lepture/mistune) that seems to be pretty similar while also more maintained, but I didn't have time to write a converter for it from scratch.

So the installation instructions (see README.md) are little bit more complicated than I would like, but hopefully still within "limits". Can you please check and let me know if it works for you?