### PR TITLE
Snippets command - Remember selected snippet

### DIFF
--- a/Global/snippets.ini
+++ b/Global/snippets.ini
@@ -51,10 +51,19 @@ Command="
 
     function askForSnippet(snippetNames, snippets) {
       var list = listSnippets ? '.list:' : ''
+
+      var settingsPrefix = 'snippets/'
+
+      var optSnippet = 'Snippet'
+      var snippetName = settings(settingsPrefix + optSnippet)
+
       var snippet = dialog(
         '.title', 'Select Snippet',
-        list + 'Snippet', snippetNames
+        '.defaultChoice', snippetName,
+        list + optSnippet, snippetNames
       ) || abort()
+
+      settings(settingsPrefix + optSnippet, listSnippets ? snippetNames[snippet] : snippet)
 
       if (listSnippets)
           return snippets[snippet]


### PR DESCRIPTION
This is a simple improvement of the "Snippets" command.

The mechanism of remembering the user input is analogous to what was done in the [Convert Markdown to ...](https://github.com/hluk/copyq-commands/blob/master/Global/convert-markdown.ini) command.