### PR TITLE
Update "Convert Markdown to": add conversion to XWiki Syntax 2.0

### DIFF
--- a/Global/README.md
+++ b/Global/README.md
@@ -128,7 +128,7 @@ the recommended mistletoe installation steps are the following:
     cd /path/to/directory/of/your/choice
     git clone https://github.com/pbodnar/mistletoe.git
     cd mistletoe
-    git checkout fix-jira-renderer
+    git checkout master-pbo
     pip3 install -e .
 
 For output format "HTML + code highlighting", an additional Python module needs to be installed:

--- a/Global/convert-markdown.ini
+++ b/Global/convert-markdown.ini
@@ -20,6 +20,7 @@ Command="
         'Jira': 'contrib.jira_renderer.JIRARenderer',
         'JSON (AST)': 'mistletoe.ast_renderer.ASTRenderer',
         'LaTeX': 'mistletoe.latex_renderer.LaTeXRenderer',
+        'XWiki Syntax 2.0': 'contrib.xwiki20_renderer.XWiki20Renderer',
     }
     
     var settingsPrefix = 'convert-markdown/';


### PR DESCRIPTION
The change is simple: enable to call another renderer created within the _mistletoe_ Markdown tool (see [branch for XWiki](https://github.com/pbodnar/mistletoe/commits/add-xwiki-renderer)).

And as the _mistletoe_ project seems to be abandoned by its author, I had to create a new dedicated master branch "master-pbo" where I merge all my / others' changes now...