### PR TITLE
Fix: Uniform data input

### DIFF
--- a/Application/copy-paste-items-as-json.ini
+++ b/Application/copy-paste-items-as-json.ini
@@ -23,6 +23,7 @@
 
     var text = JSON.stringify(itemsData, null, indent)
     copy('{ \"copyq_items\": ' + text + ' }')"
+1\Icon=\xf08b
 1\InMenu=true
 1\Name=Copy Items as JSON
 2\Command="

--- a/Application/copy-paste-items-as-json.ini
+++ b/Application/copy-paste-items-as-json.ini
@@ -23,7 +23,6 @@
 
     var text = JSON.stringify(itemsData, null, indent)
     copy('{ \"copyq_items\": ' + text + ' }')"
-1\Icon=\xf08b
 1\InMenu=true
 1\Name=Copy Items as JSON
 2\Command="
@@ -31,10 +30,12 @@
     function toData(data)
     {
       if (typeof data === 'string')
-        return data
+        return new ByteArray(data)
 
       if (data.lines)
-        return data.lines.join('\\n')
+        return new ByteArray(
+            data.lines.join('\\n')
+        )
 
       return fromBase64(data.base64)
     }


### PR DESCRIPTION
JSON pasting would create items with unencoded string content. Therefore
copy-pasting back and forth would not work, as Copy assumes byte arrays.

- Paste now turns String into ByteArray
- fromBase64 already produces ByteArray; left untouched
