### PR TITLE
Update 'move-images-to-other-tab' command

### DIFF
--- a/Automatic/move-images-to-other-tab.ini
+++ b/Automatic/move-images-to-other-tab.ini
@@ -1,7 +1,14 @@
 [Command]
-Name=Move Images to Other Tab
-Input=image/png
 Automatic=true
-Remove=true
+Command="
+    copyq:
+    var imageTab = '&Images'
+    var formats = dataFormats()
+    for (var i in formats) {
+        if (formats[i].match(/^image\\//)) {
+            setData(mimeOutputTab, imageTab)
+            break
+        }
+    }"
 Icon=\xf03e
-Tab=&Images
+Name=Move Images to Other Tab


### PR DESCRIPTION
This PR updates the `move-images-to-other-tab.ini` command so that it matches all MIME types of `image/` instead of only matching `image/png`.

This was previously discussed here https://github.com/hluk/CopyQ/discussions/1536#discussioncomment-193452.
This PR is ready for review.