### PR TITLE
Update "Convert Markdown to": store HTML as rich text, or as source code like before

### DIFF
--- a/Global/convert-markdown.ini
+++ b/Global/convert-markdown.ini
@@ -3,15 +3,15 @@ Name=Convert Markdown to ...
 Command="
     copyq:
     // # get input text to be converted
-    
+
     var markdown = str(input());
     if (!markdown) {
         copy();
         markdown = clipboard();
     }
-    
+
     // # get conversion options from user
-    
+
     var renderers = {
         'HTML': 'mistletoe.html_renderer.HTMLRenderer',
         'HTML + code highlighting': 'contrib.pygments_renderer.PygmentsRenderer', // requires: `pip3 install pygments`
@@ -22,35 +22,40 @@ Command="
         'LaTeX': 'mistletoe.latex_renderer.LaTeXRenderer',
         'XWiki Syntax 2.0': 'contrib.xwiki20_renderer.XWiki20Renderer',
     }
-    
+
     var settingsPrefix = 'convert-markdown/';
     var optFormat = 'Target format';
     var optAddToHistory = 'Add result to clipboard history';
-    
+    var optHtmlAsSourceOnly = 'Output HTML as source code only';
+
     var format = settings(settingsPrefix + optFormat);
     var addToHistory = settings(settingsPrefix + optAddToHistory) == 'true';
-    
+    var htmlAsSourceOnly = settings(settingsPrefix + optHtmlAsSourceOnly) == 'true';
+
     var options = dialog(
         '.title', 'Convert Markdown to ...',
         '.defaultChoice', format,
         optFormat, Object.keys(renderers),
-        optAddToHistory, addToHistory
+        optAddToHistory, addToHistory,
+        optHtmlAsSourceOnly, htmlAsSourceOnly
     );
-    
+
     if (!options) {
         abort();
     }
-    
+
     // # parse and store the options
-    
+
     format = options[optFormat];
     addToHistory = options[optAddToHistory];
-    
+    htmlAsSourceOnly = options[optHtmlAsSourceOnly];
+
     settings(settingsPrefix + optFormat, format);
     settings(settingsPrefix + optAddToHistory, addToHistory);
-    
+    settings(settingsPrefix + optHtmlAsSourceOnly, htmlAsSourceOnly);
+
     // # do the conversion
-    
+
     function tempFile(content) {
         var file = new TemporaryFile();
         file.openWriteOnly();
@@ -58,24 +63,60 @@ Command="
         file.close();
         return file;
     }
-    
+
     var mdFile = tempFile(markdown);
-    
+
     var cmdRes = execute('python', '-m', 'mistletoe', mdFile.fileName(), '--renderer', renderers[format]);
-    
+
     if (!cmdRes || cmdRes.exit_code != 0) {
         popup('', 'Conversion failed: ' + (cmdRes ? str(cmdRes.stderr) : 'Python executable is probably not available?'), -1);
         fail();
     }
-    
+
     // # store conversion result
-    
+
     var output = str(cmdRes.stdout);
-    if (addToHistory) {
-        add(output);
+
+    function html2text(html) {
+        // strip tags
+        var text = html.replace(/<[^>]*>?/gm, '');
+        // replace known entities
+        text = text.replace(/&([^;]+);/g, function (match, p1) {
+            var chars = {
+                'lt': '<',
+                'gt': '>',
+                'amp': '&',
+                '#39': '\'',
+                'nbsp': '\xa0',
+            }
+            return chars[p1] || p1;
+        });
+        return text;
     }
-    copy(output);
-    
+
+    var item = {};
+    if (htmlAsSourceOnly || format.indexOf('HTML') == -1) {
+        item[mimeText] = output;
+    } else {
+        item[mimeHtml] = output;
+        item[mimeText] = html2text(output);
+    }
+
+    function copyItem(item) {
+        args = [];
+        for (prop in item) {
+            args.push(prop, item[prop]);
+        }
+
+        // copy() signature: copy(mimeType, data, [mimeType, data]...)
+        copy.apply(this, args);
+    }
+
+    if (addToHistory) {
+        add(item);
+    }
+    copyItem(item);
+
     popup('', 'Markdown successfully converted to ' + format + '!');
     "
 InMenu=true


### PR DESCRIPTION
Hi, another slight, usability update to my little converter. :)

* Introducing new option "Output HTML as source code only" in the conversion dialog. Selecting this option de-facto activates the previous behavior.
* Otherwise generated HTML is stored in the HTML mimetype format, so that it can be pasted as a formatted text right away.
* The converter also tries its best to store the plain text variant for the case of pasting via the "Paste clipboard as plain text" command.