### PR TITLE
WIP: Add "Detailed Copy" Global Command

### DIFF
--- a/Global/README.md
+++ b/Global/README.md
@@ -12,6 +12,10 @@ Takes screenshot of selected part of the screen and tries to recognize text.
 Requires [GraphicsMagick](http://www.graphicsmagick.org/download.html)
 and [Tesseract](https://github.com/tesseract-ocr/tesseract/wiki/Downloads).
 
+### [Detailed Copy](detailed-copy.ini)
+
+Copies selected text or item and shows dialog for modifing copied Content and entering additional item details: Target Tab, Tag and Notes.
+
 ### [Disable Monitoring State Permanently](disable-clipboard-monitoring-state-permanently.ini)
 
 Disables clipboard monitoring permanently, i.e. the state is restored when clipboard changes even after application is restarted.

--- a/Global/detailed-copy.ini
+++ b/Global/detailed-copy.ini
@@ -5,10 +5,11 @@ Command="
     const tagsMime = 'application/x-copyq-tags';
     const tagSeparator = ', ';
     const timeMime = 'application/x-copyq-user-time';
+    const tabMime = 'application/x-copyq-user-tab';
 
     const dialogTitle = 'Detailed Copy';
     const tabField = '&Target Tab';
-    const tagField = '&Add Tag';
+    const tagField = '&Add Tags (comma separated)';
     const notesField = '&Notes';
     const contentField = '&Item Content';
     const dialogWidth = 400;
@@ -16,7 +17,9 @@ Command="
 
     const selectedItem = selectedItemData(0) || {};
     const currentTime = new Date().toISOString();
-    const currentTags = str(selectedItem[tagsMime] || '');
+    const currentTab = str(selectedTab() || config('clipboard_tab'));
+    const currentTagsString = str(selectedItem[tagsMime] || '');
+    const currentTags = currentTagsString.split(tagSeparator);
     const currentNotes = str(selectedItem[mimeItemNotes] || '');
     var currentText = str(selectedItem[mimeText] || '');
 
@@ -29,8 +32,8 @@ Command="
     }
 
     const fields = [
-      tabField, tab(),
-      tagField, userTags.map((t) => str(t)),
+      tabField, [currentTab].concat(tab().filter(t => t !== currentTab)),
+      tagField, [''].concat(userTags.map((t) => str(t))),
       // add new line to enable fake vim mode
       notesField, currentNotes + '\\n',
       contentField, currentText + '\\n',
@@ -58,22 +61,23 @@ Command="
       return '';
     };
 
-    const newTag = parseValue(newFields[tagField]);
-    const newTags = currentTags ? currentTags + tagSeparator + newTag : newTag;
+    const newTags = parseValue(newFields[tagField]).split(',').map(t => parseValue(t));
+    const newTagsString = newTags.join(tagSeparator);
+    const joinedTags = currentTagsString ? currentTagsString + tagSeparator + newTagsString : newTagsString;
     const newTab = parseValue(newFields[tabField]) || config('clipboard_tab');
     const newNotes = parseValue(newFields[notesField]);
     const newText = parseValue(newFields[contentField]);
 
-    const tagChanged = newTag && !currentTags.split(tagSeparator).includes(newTag);
+    const tagsChanged = newTagsString && newTags.some(t => !currentTags.includes(t));
     const notesChanged = newNotes !== currentNotes;
     const contentChanged = newText !== parseValue(currentText);
 
-    if (!tagChanged && !notesChanged && !contentChanged) {
+    if (!tagsChanged && !notesChanged && !contentChanged) {
       abort();
     }
 
     var item = {
-      [tagsMime]: newTags,
+      [tagsMime]: joinedTags,
       [mimeItemNotes]: newNotes,
       [mimeText]: newText,
       [timeMime]: currentTime,

--- a/Global/detailed-copy.ini
+++ b/Global/detailed-copy.ini
@@ -25,6 +25,7 @@ Command="
 
     const dialogTitle = 'Detailed Copy';
     const tabField = '&Target Tab';
+    const targetTabs = [currentTab].concat(tab().filter((t) => t !== currentTab));
     const tagsField = '&Add Tags (comma separated)';
     const removeField = '&Remove from ' + currentTab.replace('&', '') + ' Tab';
     const notesField = '&Notes';
@@ -32,84 +33,139 @@ Command="
     const dialogWidth = 400;
     const dialogHeight = 300;
 
-    const fields = [
-      tabField, [currentTab].concat(tab().filter(t => t !== currentTab)),
-      tagsField, [''].concat(userTags.map((t) => str(t))),
-      removeField, true,
-      // add new line to enable fake vim mode
-      notesField, currentNotes + '\\n',
-      contentField, currentText + '\\n',
-    ];
+    function copyMultipleItems() {
+      const options = dialog.apply(this, [
+        '.title',
+        dialogTitle,
+        tabField,
+        targetTabs,
+        removeField,
+        true,
+      ]);
 
-    const newFields = dialog.apply(
-      this,
-      [
-        '.width', dialogWidth,
-        '.height', dialogHeight,
-        '.title', dialogTitle,
-      ].concat(fields)
-    );
-
-    if (!newFields) {
-      abort();
-    }
-
-    parseValue = (data) => {
-      var hasValue = !/^\\s*$/.test(data);
-      if (hasValue) {
-        // remove trailing new lines
-        return data.replace(/\\n*$/, '');
+      if (!options) {
+        abort();
       }
-      return '';
-    };
 
-    const newTags = parseValue(newFields[tagsField]).split(',').map(t => parseValue(t));
-    const newTagsString = newTags.join(tagSeparator);
-    const joinedTags = currentTagsString ? currentTagsString + tagSeparator + newTagsString : newTagsString;
-    const newTab = parseValue(newFields[tabField]) || config('clipboard_tab');
-    const newNotes = parseValue(newFields[notesField]);
-    const newText = parseValue(newFields[contentField]);
+      const items = selectedItems();
+      const targetTab = options[tabField];
 
-    const tabChanged = newTab !== currentTab;
-    const tagsChanged = newTagsString && newTags.some(t => !currentTags.includes(t));
-    const notesChanged = newNotes !== currentNotes;
-    const contentChanged = newText !== parseValue(currentText);
+      if (targetTab && currentTab != targetTab) {
+        const toAdd = [];
+        for (i in items) {
+          const item = getitem(items[i]);
+          item[indexMime] = items[i];
+          item[timeMime] = currentTime;
+          toAdd.push(item);
+        }
 
-    if (!tabChanged && !tagsChanged && !notesChanged && !contentChanged) {
-      abort();
+        tab(targetTab);
+        add.apply(this, toAdd.reverse());
+        tab(currentTab);
+
+        if (options[removeField]) {
+          remove.apply(this, items);
+        }
+      }
     }
 
-    var item = {
-      [tagsMime]: joinedTags,
-      [mimeItemNotes]: newNotes,
-      [mimeText]: newText,
-      [timeMime]: currentTime,
-    };
+    function copySingleItem() {
+      const fields = [
+        tabField,
+        targetTabs,
+        tagsField,
+        [''].concat(userTags.map((t) => str(t))),
+        removeField,
+        true,
+        // add new line to enable fake vim mode
+        notesField,
+        currentNotes + '\\n',
+        contentField,
+        currentText + '\\n',
+      ];
 
-    if(newFields[removeField]) {
-      indexOfItem = (item) => {
-        itemsEqual = (item, i) => {
+      const newFields = dialog.apply(
+        this,
+        [
+          '.width',
+          dialogWidth,
+          '.height',
+          dialogHeight,
+          '.title',
+          dialogTitle,
+        ].concat(fields)
+      );
+
+      if (!newFields) {
+        abort();
+      }
+
+      parseValue = (data) => {
+        var hasValue = !/^\\s*$/.test(data);
+        if (hasValue) {
+          // remove trailing new lines
+          return data.replace(/\\n*$/, '');
+        }
+        return '';
+      };
+
+      const newTags = parseValue(newFields[tagsField])
+        .split(',')
+        .map((t) => parseValue(t));
+      const newTagsString = newTags.join(tagSeparator);
+      const joinedTags = currentTagsString
+        ? currentTagsString + tagSeparator + newTagsString
+        : newTagsString;
+      const newTab = parseValue(newFields[tabField]) || config('clipboard_tab');
+      const newNotes = parseValue(newFields[notesField]);
+      const newText = parseValue(newFields[contentField]);
+
+      const tabChanged = newTab !== currentTab;
+      const tagsChanged = newTagsString && newTags.some((t) => !currentTags.includes(t));
+      const notesChanged = newNotes !== currentNotes;
+      const contentChanged = newText !== parseValue(currentText);
+
+      if (!tabChanged && !tagsChanged && !notesChanged && !contentChanged) {
+        abort();
+      }
+
+      var item = {
+        [tagsMime]: joinedTags,
+        [mimeItemNotes]: newNotes,
+        [mimeText]: newText,
+        [timeMime]: currentTime,
+      };
+
+      if (newFields[removeField]) {
+        indexOfItem = (item) => {
+          itemsEqual = (item, i) => {
             for (var mime in item) {
-                if ( str(read(mime, i)) !== str(item[mime]) )
-                    return false
+              if (str(read(mime, i)) !== str(item[mime])) return false;
             }
-            return true
-        }
+            return true;
+          };
 
-        for (var i = 0; i < size(); ++i) {
-          if (itemsEqual(item, i))
-              return i
-        }
-        return 0; 
+          for (var i = 0; i < size(); ++i) {
+            if (itemsEqual(item, i)) return i;
+          }
+          return 0;
+        };
+
+        var currentIndex = indexOfItem(selectedItem);
+
+        remove(currentIndex);
       }
 
-      var currentIndex = indexOfItem(selectedItem);
-
-      remove(currentIndex);
+      tab(newTab);
+      add(item);
     }
 
-    tab(newTab);
-    add(item);"
+    if (selectedItems().length > 1) {
+      copyMultipleItems();
+      abort();
+    }
+    copySingleItem();
+"
 GlobalShortcut=meta+ctrl+c
 Icon=\xf46d
 InMenu=true

--- a/Global/detailed-copy.ini
+++ b/Global/detailed-copy.ini
@@ -1,0 +1,89 @@
+[Command]
+Command="
+    copyq:
+    const userTags = plugins.itemtags.userTags || [];
+    const tagsMime = 'application/x-copyq-tags';
+    const tagSeparator = ', ';
+    const timeMime = 'application/x-copyq-user-time';
+
+    const dialogTitle = 'Detailed Copy';
+    const tabField = '&Target Tab';
+    const tagField = '&Add Tag';
+    const notesField = '&Notes';
+    const contentField = '&Item Content';
+    const dialogWidth = 400;
+    const dialogHeight = 300;
+
+    const selectedItem = selectedItemData(0) || {};
+    const currentTime = new Date().toISOString();
+    const currentTags = str(selectedItem[tagsMime] || '');
+    const currentNotes = str(selectedItem[mimeItemNotes] || '');
+    var currentText = str(selectedItem[mimeText] || '');
+
+    if (!currentText) {
+      try {
+        sleep(200);
+        copy();
+        currentText = str(clipboard());
+      } catch (e) {}
+    }
+
+    const fields = [
+      tabField, tab(),
+      tagField, userTags.map((t) => str(t)),
+      // add new line to enable fake vim mode
+      notesField, currentNotes + '\\n',
+      contentField, currentText + '\\n',
+    ];
+
+    const newFields = dialog.apply(
+      this,
+      [
+        '.width', dialogWidth,
+        '.height', dialogHeight,
+        '.title', dialogTitle,
+      ].concat(fields)
+    );
+
+    if (!newFields) {
+      abort();
+    }
+
+    parseValue = (data) => {
+      var hasValue = !/^\\s*$/.test(data);
+      if (hasValue) {
+        // remove trailing new lines
+        return data.replace(/\\n*$/, '');
+      }
+      return '';
+    };
+
+    const newTag = parseValue(newFields[tagField]);
+    const newTags = currentTags ? currentTags + tagSeparator + newTag : newTag;
+    const newTab = parseValue(newFields[tabField]) || config('clipboard_tab');
+    const newNotes = parseValue(newFields[notesField]);
+    const newText = parseValue(newFields[contentField]);
+
+    const tagChanged = newTag && !currentTags.split(tagSeparator).includes(newTag);
+    const notesChanged = newNotes !== currentNotes;
+    const contentChanged = newText !== parseValue(currentText);
+
+    if (!tagChanged && !notesChanged && !contentChanged) {
+      abort();
+    }
+
+    var item = {
+      [tagsMime]: newTags,
+      [mimeItemNotes]: newNotes,
+      [mimeText]: newText,
+      [timeMime]: currentTime,
+    };
+
+    tab(newTab);
+    add(item);"
+GlobalShortcut=meta+ctrl+c
+Icon=\xf46d
+InMenu=true
+IsGlobalShortcut=true
+Name=Detailed Copy
+Shortcut=meta+ctrl+c

--- a/Global/detailed-copy.ini
+++ b/Global/detailed-copy.ini
@@ -6,14 +6,7 @@ Command="
     const tagSeparator = ', ';
     const timeMime = 'application/x-copyq-user-time';
     const tabMime = 'application/x-copyq-user-tab';
-
-    const dialogTitle = 'Detailed Copy';
-    const tabField = '&Target Tab';
-    const tagField = '&Add Tags (comma separated)';
-    const notesField = '&Notes';
-    const contentField = '&Item Content';
-    const dialogWidth = 400;
-    const dialogHeight = 300;
+    const indexMime = 'application/x-copyq-user-index';
 
     const selectedItem = selectedItemData(0) || {};
     const currentTime = new Date().toISOString();
@@ -22,7 +15,6 @@ Command="
     const currentTags = currentTagsString.split(tagSeparator);
     const currentNotes = str(selectedItem[mimeItemNotes] || '');
     var currentText = str(selectedItem[mimeText] || '');
-
     if (!currentText) {
       try {
         sleep(200);
@@ -31,9 +23,19 @@ Command="
       } catch (e) {}
     }
 
+    const dialogTitle = 'Detailed Copy';
+    const tabField = '&Target Tab';
+    const tagsField = '&Add Tags (comma separated)';
+    const removeField = '&Remove from ' + currentTab.replace('&', '') + ' Tab';
+    const notesField = '&Notes';
+    const contentField = '&Item Content';
+    const dialogWidth = 400;
+    const dialogHeight = 300;
+
     const fields = [
       tabField, [currentTab].concat(tab().filter(t => t !== currentTab)),
-      tagField, [''].concat(userTags.map((t) => str(t))),
+      tagsField, [''].concat(userTags.map((t) => str(t))),
+      removeField, true,
       // add new line to enable fake vim mode
       notesField, currentNotes + '\\n',
       contentField, currentText + '\\n',
@@ -61,18 +63,19 @@ Command="
       return '';
     };
 
-    const newTags = parseValue(newFields[tagField]).split(',').map(t => parseValue(t));
+    const newTags = parseValue(newFields[tagsField]).split(',').map(t => parseValue(t));
     const newTagsString = newTags.join(tagSeparator);
     const joinedTags = currentTagsString ? currentTagsString + tagSeparator + newTagsString : newTagsString;
     const newTab = parseValue(newFields[tabField]) || config('clipboard_tab');
     const newNotes = parseValue(newFields[notesField]);
     const newText = parseValue(newFields[contentField]);
 
+    const tabChanged = newTab !== currentTab;
     const tagsChanged = newTagsString && newTags.some(t => !currentTags.includes(t));
     const notesChanged = newNotes !== currentNotes;
     const contentChanged = newText !== parseValue(currentText);
 
-    if (!tagsChanged && !notesChanged && !contentChanged) {
+    if (!tabChanged && !tagsChanged && !notesChanged && !contentChanged) {
       abort();
     }
 
@@ -82,6 +85,28 @@ Command="
       [mimeText]: newText,
       [timeMime]: currentTime,
     };
+
+    if(newFields[removeField]) {
+      indexOfItem = (item) => {
+        itemsEqual = (item, i) => {
+            for (var mime in item) {
+                if ( str(read(mime, i)) !== str(item[mime]) )
+                    return false
+            }
+            return true
+        }
+
+        for (var i = 0; i < size(); ++i) {
+          if (itemsEqual(item, i))
+              return i
+        }
+        return 0; 
+      }
+
+      var currentIndex = indexOfItem(selectedItem);
+
+      remove(currentIndex);
+    }
 
     tab(newTab);
     add(item);"


### PR DESCRIPTION
## Add "Detailed Copy" Global Command

A command which provides a dialog for editing Copied Content and entering additional item details like `Target Tab`, `Item Tag` and `Item Notes`, with optional `Remove` flag.

## Technical Implementation

- `Meta+Ctr+C` - used as `Global` and `Application` shortcut
- If called within the App it fills `Tab`, `Notes`, and `Content` fields with selected item's details
- `Add Tags` dropdown is using `[''].concat(userTags)` - so field is empty by default
- `Add Tags` field can contain one value, or comma separated list of values which are parsed into array
- If called from Global it tries to copy content first to `clipboard_tab`, and then uses it to show the dialog
- On exiting dialog it checks if there was a change - if NO it `aborts` the script, otherwise it adds the item to a given tab
- If `Remove` flag is checked (by default `true`) it removes original item

## Potential improvements

- [x] Add support for adding multiple tags
- [x] Figure out is there a way to preset `Target Tab` field with `selectedItem` tab (now it always shows `&Clipboard` as it's the first element in a dropdown list of `tab()` items)
- [x] Support `coping/moving` multiple items at once
- [ ] Figure out if there is a way to add entered tags to `plugin.itemtags.userTags` array?
- [ ] Add support for other content types beside `text/plain`
- [ ] Figure out a better way to expand text fields to support `FakeVim` mode without programmatically appending `\n`?

### A story behind

I have started using copyq 2-3 days ago, and fell in love with it on first try. The number of features it offers is amazing, and it is so keyboard friendly and convenient to use.

But I have noticed that there was no such command which can offer entering full item details on the fly.

With "Detailed Copy" command it would be possible to enter `Tag`, `Tab` and `Note` for every copied item without the need to write more specific "sweeping commands" for each category like "Add Important Tag" or "Move to Tasks" or "Move to Bookmarks if starting with `http`".


### Image demonstrating Single Item Copy 

![image](https://user-images.githubusercontent.com/15067828/112830605-11504e80-9093-11eb-995d-a3cd5c9990a7.png)

### Image demonstrating Multiple Items Copy

![image](https://user-images.githubusercontent.com/15067828/112900636-0d005180-90e4-11eb-80aa-c9e5366c88e5.png)


_Please note that I have too little experience with CopyQ, and there might be some illogical things in the script, so I would welcome any ideas or suggestions for improvement. And if in any case you feel like this is not something of interest for this project, please ignore and close the PR. :)_
