### PR TITLE
Add quicksave

### DIFF
--- a/Application/QuickSave.ini
+++ b/Application/QuickSave.ini
@@ -1,0 +1,100 @@
+[Command]
+Name=QuickSave
+Command="
+    copyq:
+	// To save a clipboard item as file to a preset path using tags as it's file name.
+	// Avoid a dialogue for user input
+    
+	// Initial user setup:
+	currentPath('C:/abc/xyz')
+	// Set your default path here for once:
+    
+	var words = 3
+	// number of words to use from tags (not number of tags)
+	
+	var defaultname = 'clip'
+	// default file name if there are no tags.
+
+    var suffices = {
+      'image/svg': 'svg',
+      'image/png': 'png',
+      'image/jpeg': 'jpg',
+      'image/jpg': 'jpg',
+      'image/bmp': 'bmp',
+      'text/html': 'html',
+      'text/plain' : 'txt',
+    }
+
+    function addSuffix(fileName, format)
+    {
+      var suffix = suffices[format]
+      return suffix ? fileName + \".\" + suffix : fileName
+    }
+
+    function filterFormats(format)
+    {
+      return /^[a-z]/.test(format) && !/^application\\/x/.test(format)
+    }
+
+    function itemFormats(row)
+    {
+      return str(read('?', row))
+        .split('\\n')
+        .filter(filterFormats)
+    }
+
+    function formatPriority(format)
+    {
+      var k = Object.keys(suffices);
+      var i = k.indexOf(format);
+      return i === -1 ? k.length : i
+    }
+
+    function reorderFormats(formats)
+    {
+      formats.sort(function(lhs, rhs){
+        var i = formatPriority(lhs);
+        var j = formatPriority(rhs);
+        return i === j ? lhs.localeCompare(rhs) : i - j;
+      })
+    }
+
+    if (selectedtab()) tab(selectedtab())
+    var row = selectedtab() ? currentitem() : -1
+    var formats = itemFormats(row)
+    reorderFormats(formats)
+
+
+    var tags = str(data('application/x-copyq-tags'))
+    var nametag = tags.trim().replace(/[^a-z0-9]+/gi, '_').split('_',words).join('_')
+		// simplyfy & only take first two words from tags. can be modified.
+    var defaultFileName = currentPath()+'/'+(tags=='' ? defaultname : nametag)
+		// that's without ext
+    var id = index()+1
+		// just to start from 1.
+
+    var format = formats[0]
+
+		// name incrementally to avoid overwriting.
+    do {
+      var filename = defaultFileName +'-'+ id
+      var filenameExt = addSuffix(filename, format)
+      var f = File(filenameExt)
+      id++
+    }
+    while (f.exists())
+
+
+    if (!f.open()) {
+      popup('Failed to open \"' + f.fileName() + '\"', f.errorString())
+      abort()
+    }
+
+    f.write(selectedtab() ? getitem(currentitem())[format] : clipboard(format))
+
+    f.close()
+    popup(\"Item Saved\", 'Item saved as \"' + f.fileName() + '\".')"
+	
+InMenu=true
+Icon=\xf56d
+Shortcut=ctrl+alt+s

--- a/Application/README.md
+++ b/Application/README.md
@@ -74,7 +74,7 @@ Opens dialog for saving selected item data to a file.
 
 ### [Quick Save](QickSave.ini)
 
-Saves an item as file to a preset path using available tags as it's file name. There is no user input dialog.  
+Saves an item as file to a preset path using available tags as it's file name, without overwriting. There is no user input dialog.  
 After installation, you *must edit default folder (xyz) path*: `currentPath('C:/abc/xyz')` 
 
 Other options:  

--- a/Application/README.md
+++ b/Application/README.md
@@ -72,7 +72,7 @@ Converts text item with HTML code to HTML item.
 
 Opens dialog for saving selected item data to a file.
 
-### [Quick Save](QickSave.ini)
+### [Quick Save](QuickSave.ini)
 
 Saves an item as file to a preset path using available tags as it's file name, without overwriting. There is no user input dialog.  
 This works great along the script [show window title](../Automatic/show-window-title.ini) which saves source window title to tags while adding to clipboard.  

--- a/Application/README.md
+++ b/Application/README.md
@@ -72,6 +72,15 @@ Converts text item with HTML code to HTML item.
 
 Opens dialog for saving selected item data to a file.
 
+### [Quick Save](QickSave.ini)
+
+Saves an item as file to a preset path using available tags as it's file name. There is no user input dialog.  
+After installation, you *must edit default folder (xyz) path*: `currentPath('C:/abc/xyz')` 
+
+Other options:  
+Number of words to use from tags (not number of tags): `var words = 3`  
+Default file name if there are no tags: `var defaultname = 'clip'`
+
 ### [Search All Tabs](search-all-tabs.ini)
 
 Searches an text in all tabs and stores found items in "Search" tab.

--- a/Application/README.md
+++ b/Application/README.md
@@ -75,6 +75,7 @@ Opens dialog for saving selected item data to a file.
 ### [Quick Save](QickSave.ini)
 
 Saves an item as file to a preset path using available tags as it's file name, without overwriting. There is no user input dialog.  
+This works great along the script [show window title](../Automatic/show-window-title.ini) which saves source window title to tags while adding to clipboard.  
 After installation, you *must edit default folder (xyz) path*: `currentPath('C:/abc/xyz')` 
 
 Other options:  


### PR DESCRIPTION
### This script will be handy to *quickly save items without prompt*.
- save to a default folder. (set manually)
- uses tags for filename.
- best used with scripts that save source window title to tags.
- doesn't overwrite.
- very easy to use with shortcut.
