### PR TITLE
Use selectItem2 decide if should use default last two clipboard or not.

### DIFF
--- a/Global/diff-latest-items.ini
+++ b/Global/diff-latest-items.ini
@@ -7,7 +7,7 @@ Command="
     var item1 = null
     var item2 = null
 
-    if (selectedItem1 == undefined) {
+    if (selectedItem2 == undefined) {
         // the selected item either doesn't contain text
         // or the command is run as global shortcut.
         // select the last two clipboard in this case.


### PR DESCRIPTION
Current, when invoke compare tools from copyq pop window use Ctrl+d hotkey,
it not work because the selectItm1 always be selected by default, which cause
this script to compare the lastest clipboard with a null clipboard.