### PR TITLE
tab-for-urls Declaring tabName will avoid Exception

### DIFF
--- a/Automatic/tab-for-urls-with-title-and-icon.ini
+++ b/Automatic/tab-for-urls-with-title-and-icon.ini
@@ -2,6 +2,7 @@
 Automatic=true
 Command="
     copyq:
+    var tabName = '&URLs';
     function lower(data) {
         return str(data).toLowerCase()
     }


### PR DESCRIPTION
The command as-is will throw Exception. ReferenceError: tabName is not defined.
To avoid this, I've added     var tabName = '&URLs';
With this, the tab "URLs" is created and the formatted clipboard is correctly added in the tab.