### PR TITLE
Update "Convert Markdown to": rely on the original and updated mistletoe project

### DIFF
--- a/Global/README.md
+++ b/Global/README.md
@@ -154,19 +154,11 @@ in the main window.
 
 This script relies on the [mistletoe](https://github.com/miyuchina/mistletoe) project to do the
 actual Markdown parsing and conversion.
-This in turn requires that [Python](https://www.python.org/downloads/) 3.x is installed on the user computer.
+This in turn requires that [Python](https://www.python.org/downloads/) is installed on the user computer.
 
-At the time of writing, the mistletoe project seems to abandoned by its maintainers, so for example
-if a really working conversion to Jira markup is needed (see [PR #100](https://github.com/miyuchina/mistletoe/pull/100)),
-the recommended mistletoe installation steps are the following:
+See mistletoe's page linked above for the various possibilities of its installation.
 
-    cd /path/to/directory/of/your/choice
-    git clone https://github.com/pbodnar/mistletoe.git
-    cd mistletoe
-    git checkout master-pbo
-    pip3 install -e .
-
-For output format "HTML + code highlighting", an additional Python module needs to be installed:
+For output format "HTML + code highlighting", an additional Python package needs to be installed:
 
     pip3 install pygments
 

--- a/Global/convert-markdown.ini
+++ b/Global/convert-markdown.ini
@@ -14,13 +14,13 @@ Command="
 
     var renderers = {
         'HTML': 'mistletoe.html_renderer.HTMLRenderer',
-        'HTML + code highlighting': 'contrib.pygments_renderer.PygmentsRenderer', // requires: `pip3 install pygments`
-        'HTML + GitHub Wiki': 'contrib.github_wiki.GithubWikiRenderer',
-        'HTML + MathJax': 'contrib.mathjax.MathJaxRenderer',
-        'Jira': 'contrib.jira_renderer.JIRARenderer',
+        'HTML + code highlighting': 'mistletoe.contrib.pygments_renderer.PygmentsRenderer', // requires: `pip3 install pygments`
+        'HTML + GitHub Wiki': 'mistletoe.contrib.github_wiki.GithubWikiRenderer',
+        'HTML + MathJax': 'mistletoe.contrib.mathjax.MathJaxRenderer',
+        'Jira': 'mistletoe.contrib.jira_renderer.JIRARenderer',
         'JSON (AST)': 'mistletoe.ast_renderer.ASTRenderer',
         'LaTeX': 'mistletoe.latex_renderer.LaTeXRenderer',
-        'XWiki Syntax 2.0': 'contrib.xwiki20_renderer.XWiki20Renderer',
+        'XWiki Syntax 2.0': 'mistletoe.contrib.xwiki20_renderer.XWiki20Renderer',
     }
 
     var settingsPrefix = 'convert-markdown/';


### PR DESCRIPTION
mistletoe gets new updates in its original Git repository again, so we can safely switch to that one now.

WARNING: This also means using updated paths to mistletoe's renderers from the "contrib" folder (see miyuchina/mistletoe#167) in the Convert command. This change is not available in the released mistletoe version [0.9.0](https://github.com/miyuchina/mistletoe/releases/tag/v0.9.0) yet, so using this command version means one needs to use mistletoe directly from GitHub (`git clone ...` + `pip3 install -e .`) for now.