### PR TITLE
trim language string from dialog

### DIFF
--- a/Global/copy-text-in-image.ini
+++ b/Global/copy-text-in-image.ini
@@ -34,7 +34,7 @@ Command="
       // Page segmentation mode:
       //   6 - Assume a single uniform block of text.
       '--psm', '6',
-      '-l', language,
+      '-l', language.trim(),
       'stdin', 'stdout',
       null, imageData)
     if (!result)


### PR DESCRIPTION
Problem:

I sometimes got

    CopyQ Note [2023-05-01 18:01:52.644] <Server-8336>:    Failed loading language 'deu
    '

I don't really understand but the choice dialog seems to add a newline to the selected language string (only sometimes?) or isn't it removed by the `split('\n')` call? However, calling a `trim()` on `language` fixed the problem for me.