### PR TITLE
Add decode-google-search-url.ini

### DIFF
--- a/Automatic/README.md
+++ b/Automatic/README.md
@@ -15,6 +15,20 @@ or shown in GUI.
 
 Automatically adds new clipboard to tab with same name as title of the window where copy operation was performed.
 
+### [Decode URLs from Google Search](decode-google-search-url.ini)
+
+Automatically decodes a URL from Google Search when it's copied to the clipboard. For example, when the following URL is copied to the clipboard:
+
+> https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwj95u6osNn_AhW0hJUCHePPAa8QFnoECA4QAQ&url=https%3A%2F%2Fhluk.github.io%2FCopyQ%2F
+
+It is replaced by:
+
+> https://hluk.github.io/CopyQ/
+
+which is the decoded `&url` part from the original URL. The original URL is also added to the active tab's history, but it is not copied to the clipboard.
+
+Note: needs a Python interpreter to be available at `/bin/python`.
+
 ### [Ignore Images when Text is Available](ignore-images-when-text-is-available.ini)
 
 This is useful for ignoring cells copied as images from Microsoft Excel and LibreOffice Calc.

--- a/Automatic/decode-google-search-url.ini
+++ b/Automatic/decode-google-search-url.ini
@@ -1,0 +1,39 @@
+[Command]
+Name=Decode Google Search URL
+Automatic=true
+Command="
+    copyq:
+    var url = str(clipboard())
+    var result = execute(
+      '/bin/python',
+      '-c',
+        'try:\\n' +
+        '  from urllib.parse import urlparse, parse_qs, unquote\\n' +
+        'except ImportError:\\n' +
+        '  from urlparse import urlparse, parse_qs\\n' +
+        '  from urllib import unquote\\n' +
+        'import sys\\n' +
+        'url = sys.argv[1]\\n' +
+        'parsed_url = urlparse(url)\\n' +
+        'qs = parse_qs(parsed_url.query)\\n' +
+        'if \"url\" in qs:\\n' +
+        '  print(unquote(qs[\"url\"][0]))',
+      url
+    )
+    if (
+      result &&
+      result.exit_code == 0 &&
+      str(result.stdout)
+    ) {
+      add(url)
+      var stdout = str(result.stdout)
+      add(stdout)
+      copy(stdout)
+    } else {
+      add(url)
+      copy(url)
+    }"
+Icon=\xf044
+Match=^https?:\\/\\/(www\\.)?google\\.com\\/url\\?
+Output=text/plain
+Transform=true


### PR DESCRIPTION
I'm using Python for this because, as far as I'm aware, [`URLSearchParams`](https://nodejs.org/api/url.html#new-urlsearchparams) is not available for the `copyq:` scripts. An alternative would be to provide a rudimentary query string parsing function in Javascript akin to https://stackoverflow.com/a/13419367/8401696, but I don't know if that's worth it. I'm open to suggestions.