### PR TITLE
Create bookmarks.ini

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -12,6 +12,12 @@ automatic commands on it.
 Only checksum of the text (salted) is stored in the blocklist so this can be
 safely used with passwords (the texts are not stored anywhere).
 
+### [Bookmarks](bookmarks.ini)
+
+Allows you to set a mark on an item, then later restore that mark to the clipboard. 
+
+The implementation uses special tags with a "mark:" prefix, and when a mark is set, removes  that tag from any items that contain that tag.
+
 ### [Clear Clipboard After Interval](clear-clipboard-after-interval.ini)
 
 Clears clipboard after an interval (30 seconds by default).

--- a/Scripts/bookmarks.ini
+++ b/Scripts/bookmarks.ini
@@ -1,0 +1,51 @@
+[Commands]
+1\Command="
+    const prefix = 'mark:';
+    global.setMark = function(name) {
+      if (!name) {
+        name = dialog('.title', 'Assign to register', 'Name', '');
+      }
+      const tag = prefix + name;
+      // Filter to only items that have a mark tag
+      const sel = ItemSelection().select(/mark:/, plugins.itemtags.mimeTags);
+      plugins.itemtags.untag(tag, ...sel.rows());
+
+      // TODO: allow selecting multiple items?
+      plugins.itemtags.tag(tag, currentItem());
+    };
+
+    global.listMarks = function() {
+      const s = new Set();
+      // Support multiple items?
+      for (let i = 0; i < size(); i++) {
+        for (const tag of plugins.itemtags.tags(i)) {
+          if (tag.startsWith(prefix)) {
+            s.add(tag.slice(prefix.length));
+          }
+        }
+      }
+      return Array.from(s);
+    };
+
+    global.copyMark = function(name) {
+      if (!name) {
+          name = menuItems.apply(global, listMarks());
+      }
+      const tag = prefix + name;
+      const len = size();
+      for (let i = 0; i < len; i++) {
+        if (plugins.itemtags.hasTag(tag, i)) {
+          select(i);
+          return;
+        }
+      }
+    }"
+1\Icon=\xe0bb
+1\IsScript=true
+1\Name=Bookmarks
+2\Command="
+    copyq setMark"
+2\Icon=\xf15b
+2\InMenu=true
+2\Name=set mark
+size=2

--- a/Scripts/bookmarks.ini
+++ b/Scripts/bookmarks.ini
@@ -48,4 +48,10 @@
 2\Icon=\xf15b
 2\InMenu=true
 2\Name=set mark
-size=2
+3\Command="
+    copyq copyMark"
+3\Icon=\xf15b
+3\InMenu=true
+3\IsGlobalShortcut=true
+3\Name=Restore mark
+size=3


### PR DESCRIPTION
Add bookmark functionality

This allows you to set a mark on an item, then later restore that mark to the clipboard. 

This is similar to how vim registers work. 

The implementation uses special tags with a "mark:" prefix, and when a mark is set, removes  that tag from any items that contain that tag.

Can be used with

 itemtags\tags="\\\\1;;#0000ff;;\xe0bb;;;;mark:(.*);;"

to get nicer presentation of the marks.