### PR TITLE
Clarify description for Reset Empty Clipboard/Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,9 @@ Requires [marked](https://marked.js.org/).
 
 ## [Reset Empty Clipboard/Selection](commands/reset-empty-clipboard.ini)
 
-Resets last clipboard text (or X11 selection) if it's cleared.
+Automatically restores previous clipboard text if cleared. Also restores
+[the primary selection](https://copyq.readthedocs.io/en/latest/scripting-api.html#primary-selection)
+if cleared.
 
 ## [Save Item/Clipboard To a File](commands/save-item-clipboard-to-file.ini)
 

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -64,7 +64,9 @@ This command makes the last set state persistent between application launches.
 
 ### [Reset Empty Clipboard/Selection](../commands/reset-empty-clipboard.ini)
 
-Resets last clipboard text (or X11 selection) if it's cleared.
+Automatically restores previous clipboard text if cleared. Also restores
+[the primary selection](https://copyq.readthedocs.io/en/latest/scripting-api.html#primary-selection)
+if cleared.
 
 ### [Show on Start](../commands/show-on-start.ini)
 


### PR DESCRIPTION
Reword the description to be less ambiguous: make it clear the command restores (not clears) clipboard contents, and replace "X11 selection" with user-friendly language.

Fixes #133

Assisted-by: Claude (Anthropic)