### PR TITLE
Add Activate Nth Item command; Map digit 0 to the 10th item when indexed from 1

### DIFF
--- a/Application/README.md
+++ b/Application/README.md
@@ -2,6 +2,12 @@
 
 This section contains commands which can be executed from tool bar, menu or with shortcut.
 
+### [Activate Nth Item](../commands/activate-nth-item.ini)
+
+Press a digit key (0-9) in the main window to instantly activate and paste the item at that row index.
+
+Respects `row_index_from_one` configuration.
+
 ### [Clear Clipboard Tab](../commands/clear-clipboard-tab.ini)
 
 Remove all items from clipboard tab using menu item (or custom shortcut).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Submit new pull request in this repository if you want to share a command.
 
 # Commands
 
+## [Activate Nth Item](commands/activate-nth-item.ini)
+
+Press a digit key (0-9) in the main window to instantly activate and paste the item at that row index.
+
+Respects `row_index_from_one` configuration.
+
 ## [Auto Preview Image or Long-text](commands/auto-preview.ini)
 
 Automatically preview images and long-text, and support manual preview with `Space` key. You can set the number of lines and characters for long text.

--- a/commands/activate-nth-item.ini
+++ b/commands/activate-nth-item.ini
@@ -1,10 +1,11 @@
 [Command]
 Command="
     copyq:
-    var n = str(data(mimeShortcut)).slice(-1)
+    let n = Number(str(data(mimeShortcut)).slice(-1))
     if (config('row_index_from_one') === 'true') {
-        n -= 1
+        n = (n + 9) % 10
     }
+    selectItems(n)
     select(n)
     hide()
     paste()"

--- a/commands/activate-nth-item.ini
+++ b/commands/activate-nth-item.ini
@@ -1,0 +1,14 @@
+[Command]
+Command="
+    copyq:
+    var n = str(data(mimeShortcut)).slice(-1)
+    if (config('row_index_from_one') === 'true') {
+        n -= 1
+    }
+    select(n)
+    hide()
+    paste()"
+Icon=\xf0cb
+InMenu=true
+Name=Activate Nth Item
+Shortcut=0, 1, 2, 3, 4, 5, 6, 7, 8, 9

--- a/commands/select-nth-item.ini
+++ b/commands/select-nth-item.ini
@@ -1,9 +1,9 @@
 [Command]
 Command="
     copyq:
-    var n = str(data(mimeShortcut)).slice(-1)
+    let n = Number(str(data(mimeShortcut)).slice(-1))
     if (config('row_index_from_one') === 'true') {
-        n -= 1
+        n = (n + 9) % 10
     }
 
     if (config('activate_closes') === 'true') {


### PR DESCRIPTION
Press a digit key (0-9) in the main window to activate and paste the
item at that row index. Respects row_index_from_one configuration.

See also: https://github.com/hluk/CopyQ/issues/3591

Applies to Activate Nth Item and Select Nth Item commands.

Assisted-by: Claude (Anthropic)